### PR TITLE
Fix multipart header parsing

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -392,7 +392,7 @@ const parseMultipartHeader = (header: string): { name: string;[key: string]: str
     acc[key] = v[2]
     return acc
   }, {})
-  if (disposition !== 'form-data') null
+  if (disposition !== 'form-data') return null
   //@ts-ignore
   return multipartHeader
 }


### PR DESCRIPTION
## Summary
- fix multipart header parser to return `null` for non-`form-data`
- maintain existing tests