### PR TITLE
Fix repeated query param parsing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -71,7 +71,13 @@ export default async (galbe: Galbe, port?: number, hostname?: string) => {
         const inHeaders: Record<string, any> = {}
         for (let [k, v] of req.headers) inHeaders[k] = v
         let inQuery: Record<string, any> = {}
-        for (let [k, v] of url.searchParams) inQuery[k] = v
+        for (let [k, v] of url.searchParams) {
+          if (k in inQuery) {
+            const cur = inQuery[k]
+            if (Array.isArray(cur)) inQuery[k] = [...cur, v]
+            else inQuery[k] = [cur, v]
+          } else inQuery[k] = v
+        }
         let inParams = requestPathParser(url.pathname, route.path)
 
         context.body = !EMPTY_BODY_METHODS.includes(req.method)

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -300,16 +300,31 @@ describe('parser', () => {
       }
     ]
 
-    for (let { p, expected } of cases) {
-      let search = new URLSearchParams()
-      for (const [k, v] of Object.entries(p)) search.append(k, v as string)
+  for (let { p, expected } of cases) {
+    let search = new URLSearchParams()
+    for (const [k, v] of Object.entries(p)) search.append(k, v as string)
 
-      let resp = await fetch(`http://localhost:${port}/query/params/schema?${search.toString()}`)
-      let body = await resp.json()
+    let resp = await fetch(`http://localhost:${port}/query/params/schema?${search.toString()}`)
+    let body = await resp.json()
 
-      expect(resp.status).toBe(expected.status ?? 200)
-      expect(body).toEqual(expected.body)
-    }
+    expect(resp.status).toBe(expected.status ?? 200)
+    expect(body).toEqual(expected.body)
+  }
+})
+
+  test('query params, duplicates', async () => {
+    const search = new URLSearchParams()
+    search.append('p1', 'one')
+    search.append('p1', 'two')
+    search.append('p2', '3.14')
+    search.append('p3', 'true')
+    search.append('p4', '42')
+
+    let resp = await fetch(`http://localhost:${port}/query/params/schema?${search.toString()}`)
+    let body = await resp.json()
+
+    expect(resp.status).toBe(400)
+    expect(body).toEqual({ query: { p1: 'Multiple values found' } })
   })
 
   test('body, json, schema object', async () => {


### PR DESCRIPTION
## Summary
- handle multiple query parameters with the same name
- add regression test for duplicate query parameters

## Testing
- `bun test`
- `bun run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687e8fbef3e88331b2ab683af3481c55